### PR TITLE
Added support scripts for secure mode

### DIFF
--- a/xbridge/src/xbridge-setup.in
+++ b/xbridge/src/xbridge-setup.in
@@ -14,18 +14,31 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+NETIF=${2:-wlan0}
+
 start() {
   MAC=`cat /sys/class/net/wlan0/address`
   modprobe g_ether host_addr=$MAC
   ip link set dev usb0 up
+
+  if [ $NETIF != "wlan0" ]; then
+    # Need to start dhcp on wlan0 interface, so enf0 can use
+    # wlan0 to connect to ENF
+    udhcpc -i wlan0 -R -p /run/udhcpc
+  fi
 }
 
 stop() {
+  if [ $NETIF != "wlan0" ]; then
+    # Only need an IP on wlan0 while secure mode is active
+    kill `cat /run/udhcpc`
+  fi
+
   ip link set dev usb0 down
   modprobe -r g_ether
 }
 
 case $1 in
   start|stop) "$1" ;;
-  *) echo "Usage: $0 start|stop" ;;
+  *) echo "Usage: $0 start|stop netif" ;;
 esac

--- a/xbridge/systemd/CMakeLists.txt
+++ b/xbridge/systemd/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 configure_file(xbridge.service.in xbridge.service @ONLY)
 configure_file(xbridge-setup.service.in xbridge-setup.service @ONLY)
 
+configure_file(xbridges.service.in xbridges.service @ONLY)
+configure_file(xbridges-setup.service.in xbridges-setup.service @ONLY)
+
 set(INSTALL_SYSTEMDDIR "/lib/systemd/system")
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/xbridge.service
         ${CMAKE_CURRENT_BINARY_DIR}/xbridge-setup.service
+        ${CMAKE_CURRENT_BINARY_DIR}/xbridges.service
+        ${CMAKE_CURRENT_BINARY_DIR}/xbridges-setup.service
   DESTINATION ${INSTALL_SYSTEMDDIR}
 )

--- a/xbridge/systemd/xbridge-setup.service.in
+++ b/xbridge/systemd/xbridge-setup.service.in
@@ -1,11 +1,13 @@
 [Unit]
-Description=setup for xbridge service
+Description=setup for xbridge service (pass-through mode)
+Requires=wpa_supplicant-nl80211@wlan0.service
+After=wpa_supplicant-nl80211@wlan0.service
 BindsTo=xbridge.service
 
 [Service]
 Type=oneshot
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup start
-ExecStop=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup stop
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup start wlan0
+ExecStop=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup stop wlan0
 RemainAfterExit=yes
 
 [Install]

--- a/xbridge/systemd/xbridge.service.in
+++ b/xbridge/systemd/xbridge.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=xbridge service
+Description=xbridge service (pass-through mode)
 After=xbridge-setup.service
 BindsTo=xbridge-setup.service
 

--- a/xbridge/systemd/xbridges-setup.service.in
+++ b/xbridge/systemd/xbridges-setup.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=setup for xbridge service (secure mode)
+Requires=wpa_supplicant-nl80211@wlan0.service
+After=wpa_supplicant-nl80211@wlan0.service
+BindsTo=xbridges.service
+
+[Service]
+Type=oneshot
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup start enf0
+ExecStop=@CMAKE_INSTALL_FULL_BINDIR@/xbridge-setup stop enf0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/xbridge/systemd/xbridges.service.in
+++ b/xbridge/systemd/xbridges.service.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=xbridge service (secure mode)
+BindsTo=xbridges-setup.service
+After=xbridges-setup.service
+BindsTo=enftun@enf0.service
+After=enftun@enf0.service
+
+[Service]
+Type=simple
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge -2 -n enf0
+ProtectSystem=true
+ProtectHome=true
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Makes it possible to run 'systemctl start xbridges' to activate secure mode.

Note that I added enftun@enf0 as a requirement for xbridges as well.
We should probably no longer start enftun@enf0 during boot anymore?
It's not needed for pass-through mode.

This still needs changes to enftun to make secure mode work as required.
