### PR TITLE
Have xbridge use configured MAC addresses

### DIFF
--- a/xbridge/src/xbridge.c
+++ b/xbridge/src/xbridge.c
@@ -23,6 +23,8 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <linux/types.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
 
 #define LogDebug(format, ...) syslog(LOG_DEBUG, format, ##__VA_ARGS__)
 #define LogCrit(format, ...) syslog(LOG_CRIT, format, ##__VA_ARGS__)
@@ -30,15 +32,23 @@
 
 #define MAX(a,b) ((a) > (b) ? (a) : (b))
 
+#define ETHER_TYPE_IPv6 0x86dd
+
 int quit = 0;
 int stats = 0;
 
 struct pcapDeviceInfo {
-    const char *name;
+    const char *name; // Interface to use to inject packets
+    const char *mac; // Interface to copy MAC address from
     pcap_t     *descr;
     int         fd;
     enum { eL2DoneTouch, eL2Strip, eL2Prepend } l2handling;
 };
+
+struct ethernetHeader {
+    unsigned char dst[6], src[6];
+    __u16         ether_type;
+} eHeader;
 
 void signal_handler(int n)
 {
@@ -71,6 +81,55 @@ pcap_t* createDesc(const char * const iface, int snaplen, int promisc)
     LogInfo("Attached to network interface %s, snaplen %d", iface, snaplen);
 
     return descr;
+}
+
+//#define DO_LOG_MAC
+#ifdef DO_LOG_MAC
+const char * const mac2ascii(const unsigned char *mac)
+{
+    static char ascii[24]; // Need only 18 bytes, including terminating zero
+
+    char *p = ascii;
+
+    for (int i=0; i<6; ++i) {
+        *p++ = "0123456789abcdef"[mac[i]>>4];
+        *p++ = "0123456789abcdef"[mac[i]&0xf];
+        *p++ = ':';
+    }
+
+    p[-1] = 0;
+
+    return ascii;
+}
+#endif
+
+void getMac(const char * const iface_name, unsigned char *mac, const char * const iface_mac)
+{
+    struct ifreq ifr;
+
+    int fd = socket(PF_INET, SOCK_STREAM, 0);
+    if (0 > fd) {
+        LogCrit("socket(): error %d (%s)", errno, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    strncpy(ifr.ifr_name, iface_mac, sizeof(ifr.ifr_name)-1);
+    ifr.ifr_name[sizeof(ifr.ifr_name)-1]='\0';
+
+    if (0 > ioctl(fd, SIOCGIFHWADDR, &ifr)) {
+        LogCrit("ioctl(): error %d (%s)", errno, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    close(fd);
+
+    for (int i=0; i<6; ++i) {
+        mac[i] = ifr.ifr_hwaddr.sa_data[i];
+    }
+
+#ifdef DO_LOG_MAC
+    LogInfo("Interface %s: using MAC %s", iface_name, mac2ascii(mac));
+#endif
 }
 
 void showStats(pcap_t *p, const char *iface)
@@ -107,19 +166,8 @@ void callback(u_char *user, const struct pcap_pkthdr *header, const u_char *data
         break;
 
     case eL2Strip: // Strip L2 data when sending packets to enf0
-        if (ntohs(((struct ethernetHeader*)data)->ether_type) == 0x86dd) {
+        if (ntohs(((struct ethernetHeader*)data)->ether_type) == ETHER_TYPE_IPv6) {
             // An IPv6 Ethernet frame
-
-            if (0 == have_eheader) {
-                // Prepare Ethernet header which will be prepended when receiving
-                // packets from enf0
-
-                struct ethernetHeader *h = (struct ethernetHeader *) buf;
-                memcpy(h->dst, ((struct ethernetHeader*)data)->src, 6);
-                memcpy(h->src, ((struct ethernetHeader*)data)->dst, 6);
-                h->ether_type = ((struct ethernetHeader*)data)->ether_type;
-                have_eheader = 1;
-            }
 
             // Send packet, but strip Ethernet header (which is 14 bytes)
             if (0 != pcap_sendpacket(iface->descr,
@@ -131,17 +179,20 @@ void callback(u_char *user, const struct pcap_pkthdr *header, const u_char *data
         break;
 
     case eL2Prepend: // Add (prepend) L2 header data to packets to host
-        if (0 != have_eheader) {
+        if (0 == have_eheader) {
+            // Copy prepared Ethernet header to buf just once
+            memcpy(buf, &eHeader, sizeof(eHeader));
+            have_eheader = 1;
+        }
 
-            // Copy packet data after local Ethernet header
-            memcpy(buf+sizeof(struct ethernetHeader),data,header->len);
+        // Copy packet data after local Ethernet header
+        memcpy(buf+sizeof(struct ethernetHeader),data,header->len);
 
-            // Then send IPv6 packet data
-            if (0 != pcap_sendpacket(iface->descr,
-                                     buf,
-                                     sizeof(struct ethernetHeader)+header->len)) {
-                LogCrit("pcap_sendpacket(): %s", pcap_geterr(iface->descr));
-            }
+        // Then send IPv6 packet data
+        if (0 != pcap_sendpacket(iface->descr,
+                                 buf,
+                                 sizeof(struct ethernetHeader)+header->len)) {
+            LogCrit("pcap_sendpacket(): %s", pcap_geterr(iface->descr));
         }
         break;
     }
@@ -149,8 +200,8 @@ void callback(u_char *user, const struct pcap_pkthdr *header, const u_char *data
 
 int main(int argc, char **argv)
 {
-    struct pcapDeviceInfo host_if = { .name = "usb0", .l2handling = eL2DoneTouch };
-    struct pcapDeviceInfo net_if = { .name = "wlan0", .l2handling = eL2DoneTouch };
+    struct pcapDeviceInfo host_if = { .name = "usb0", .mac = "usb0", .l2handling = eL2DoneTouch };
+    struct pcapDeviceInfo net_if = { .name = "wlan0", .mac = "wlan0", .l2handling = eL2DoneTouch };
 
     int snaplen = 8192;
     int opt;
@@ -184,6 +235,12 @@ int main(int argc, char **argv)
 
     net_if.descr = createDesc(net_if.name, snaplen, 0);
     net_if.fd = pcap_get_selectable_fd(net_if.descr);
+
+    if (eL2DoneTouch != net_if.l2handling) {
+        getMac(host_if.name, eHeader.src, host_if.mac);
+        getMac(net_if.name, eHeader.dst, net_if.mac);
+        eHeader.ether_type = htons(ETHER_TYPE_IPv6);
+    }
 
     int maxfd = MAX(host_if.fd,net_if.fd);
 


### PR DESCRIPTION
Have xbridge read the necessary MAC addresses to use (when forwaring IPv6 packets from the enf0 interface to the host) from the /sys/class configuration, to make sure we get this correct 100% of the time.