### PR TITLE
captived: support connman wifi config

### DIFF
--- a/captived/integration-tests/config/default/data/connman/passthrough/wifi.config
+++ b/captived/integration-tests/config/default/data/connman/passthrough/wifi.config
@@ -1,0 +1,6 @@
+[service_wifi_passthrough_managed_psk]
+Type = wifi
+Name = passthrough
+Passphrase = passthrough-passphrase
+IPv4=off
+IPv6=off

--- a/captived/integration-tests/config/default/data/connman/secure-host/wifi.config
+++ b/captived/integration-tests/config/default/data/connman/secure-host/wifi.config
@@ -1,0 +1,4 @@
+[service_wifi_secure_host_managed_psk]
+Type = wifi
+Name = secure-host
+Passphrase = secure-host-passphrase

--- a/captived/integration-tests/config/default/data/wpa_supplicant/wpa_supplicant-nl80211-wlan0.conf
+++ b/captived/integration-tests/config/default/data/wpa_supplicant/wpa_supplicant-nl80211-wlan0.conf
@@ -1,8 +1,0 @@
-ctrl_interface=/var/run/wpa_supplicant
-ap_scan=1
-
-network={
-        ssid="xaprc_default"
-        psk="password123!"
-}
-

--- a/captived/src/defines.hpp
+++ b/captived/src/defines.hpp
@@ -11,9 +11,10 @@ const std::string FILE_SERIAL_NUMBER = "/rom/serial";
 const std::string FILE_WIFI_MAC_ADDRESS = "/rom/mac_address/1";
 const std::string FILE_ENF_CONTROL_ADDRESS = "/data/enftun/enf1/address";
 const std::string FILE_ENF_DATA_ADDRESS = "/data/enftun/enf0/address";
-const std::string FILE_FIRMWARE_VERSION = "/etc/mender/artifact_info"; 
+const std::string FILE_FIRMWARE_VERSION = "/etc/mender/artifact_info";
 const std::string FILE_ROUTER_MODE = "/data/default_target";
-const std::string FILE_WIFI_CONFIG = "/data/wpa_supplicant/wpa_supplicant-nl80211-wlan0.conf";
+const std::string FILE_WIFI_CONFIG_PASSTHROUGH = "/data/connman/passthrough/wifi.config";
+const std::string FILE_WIFI_CONFIG_SECURE_HOST = "/data/connman/secure_host/wifi.config";
 const std::string FILE_REBOOT_EXE = "/sbin/reboot";
 
 const std::string URI_SERIAL_NUMBER = "/serial_number";
@@ -25,6 +26,8 @@ const std::string URI_ROUTER_MODE = "/mode";
 const std::string URI_ROUTER_STATUS = "/";
 const std::string URI_WIFI = "/wifi";
 const std::string URI_WIFI_CONFIG = "/wifi/config";
+const std::string URI_WIFI_CONFIG_PASSTHROUGH = "/wifi/config/passthrough";
+const std::string URI_WIFI_CONFIG_SECURE_HOST = "/wifi/config/secure_host";
 const std::string URI_WIFI_STATUS = "/wifi/status";
 const std::string URI_REBOOT = "/reboot";
 

--- a/captived/src/main.cpp
+++ b/captived/src/main.cpp
@@ -78,14 +78,20 @@ int main(int argc, char *argv[]) {
     rest_resource_root root_resource = rest_resource_root(root_path);
     embed_server.register_resource(root_resource);
 
-    rest_wifi_config wifi_config_resource = rest_wifi_config (
-                            URI_WIFI_CONFIG,
-                            root_path + FILE_WIFI_CONFIG
+    rest_wifi_config wifi_config_passthrough_resource = rest_wifi_config (
+                            URI_WIFI_CONFIG_PASSTHROUGH,
+                            root_path + FILE_WIFI_CONFIG_PASSTHROUGH
                             );
-    embed_server.register_resource(wifi_config_resource);
+    embed_server.register_resource(wifi_config_passthrough_resource);
+
+    rest_wifi_config wifi_config_secure_host_resource = rest_wifi_config (
+                            URI_WIFI_CONFIG_SECURE_HOST,
+                            root_path + FILE_WIFI_CONFIG_SECURE_HOST
+                            );
+    embed_server.register_resource(wifi_config_secure_host_resource);
 
     rest_reboot reboot_res = rest_reboot (
-                            URI_REBOOT, 
+                            URI_REBOOT,
                             root_path + FILE_REBOOT_EXE
                             );
     embed_server.register_resource(reboot_res);


### PR DESCRIPTION
The patch updates captived to support the new connman wifi config setup on the router card, rather than the old raw wpa_supplicant setup.

The connman approach requires different config files for passthrough and secure modes, so this patch also exposes two new endpoints, `/wifi/config/passthrough` and `/wifi/config/secure-host`.

Fixed #46 