### PR TITLE
captived: speed up tests

### DIFF
--- a/captived/integration-tests/mode_Test.py
+++ b/captived/integration-tests/mode_Test.py
@@ -29,8 +29,6 @@ class mode_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super(mode_Test, self).setUp()
-        # Wait for the embedded server to start up.
-        time.sleep(1.1)
 
     def tearDown(self):
         # put back to secure_host

--- a/captived/integration-tests/reboot_Test.py
+++ b/captived/integration-tests/reboot_Test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+
 
 import json
 import os
@@ -29,8 +29,7 @@ class reboot_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super().setUp()
-        # Wait for the embedded server to start up.
-        time.sleep(1.1)
+
         self.last_reboot_file = os.path.join(DATA_PATH, 'sbin', 'last_reboot.txt')
         if os.path.isfile(self.last_reboot_file):
             os.remove(self.last_reboot_file)

--- a/captived/integration-tests/root_level_status_Test.py
+++ b/captived/integration-tests/root_level_status_Test.py
@@ -28,8 +28,6 @@ class root_level_status_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super(root_level_status_Test, self).setUp()
-        # Wait for the server to start up
-        time.sleep(1.1)
 
     def tearDown(self):
         super(root_level_status_Test, self).tearDown()

--- a/captived/integration-tests/simple_get_Test.py
+++ b/captived/integration-tests/simple_get_Test.py
@@ -40,8 +40,6 @@ class simple_get_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super(simple_get_Test, self).setUp()
-        # Wait for the embedded server to start up.
-        time.sleep(1.1)
 
     def tearDown(self):
         # put back to secure_host

--- a/captived/integration-tests/wifi_config_Test.py
+++ b/captived/integration-tests/wifi_config_Test.py
@@ -35,8 +35,6 @@ class wifi_config_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super(wifi_config_Test, self).setUp()
-        # Wait for the embedded server to start up.
-        time.sleep(1.1)
 
     def tearDown(self):
         super(wifi_config_Test, self).tearDown()

--- a/captived/integration-tests/wifi_status_Test.py
+++ b/captived/integration-tests/wifi_status_Test.py
@@ -32,8 +32,6 @@ class wifi_status_Test(test.SharedServer, test.IntegrationTestCase):
 
     def setUp(self):
         super(wifi_status_Test, self).setUp()
-        # Wait for the embedded server to start up.
-        time.sleep(1.1)
 
     def tearDown(self):
         super(wifi_status_Test, self).tearDown()

--- a/captived/integration-tests/xaptum/embedded_server.py
+++ b/captived/integration-tests/xaptum/embedded_server.py
@@ -8,6 +8,19 @@ BIN  = os.path.join(CWD, 'captived')
 DEVNULL = open(os.devnull, 'wb')
 atexit.register(lambda: DEVNULL.close())
 
+def wait_for_connect(attempts=10, timeout=0.1):
+    import socket
+    import time
+    while attempts > 0:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            try:
+                s.connect(('::1', 4000))
+                return
+            except:
+                attempts -= 1
+                time.sleep(timeout)
+    raise IOError("Failed to start to server")
+
 class Embedded_Server(object):
 
     def __init__(self, cwd=CWD, bin=BIN, args=None, quiet=False):
@@ -18,11 +31,13 @@ class Embedded_Server(object):
 
         self.process = None
 
-    def start(self):
+    def start(self, wait=True):
         args   = [self.bin] + self.args
         stdout = DEVNULL if self.quiet else None
         stderr = DEVNULL if self.quiet else None
         self.process = subprocess.Popen(args, cwd=self.cwd, stdout=stdout, stderr=stderr)
+        if wait:
+            wait_for_connect()
 
     def terminate(self):
         self.process.terminate()


### PR DESCRIPTION
Speed up integration tests by 
- removing unnecessary sleeps
- replacing the pessimistic sleep after captived startup with a proactive check for its availability

Reduces the total test time by an order of magnitude on my machine.