### PR TITLE
captived: make system helper non-copyable

### DIFF
--- a/captived/src/rest/line_resource.cpp
+++ b/captived/src/rest/line_resource.cpp
@@ -4,7 +4,7 @@
 namespace captived {
 namespace rest {
 
-line_resource::line_resource(std::string path, system system,
+line_resource::line_resource(std::string path, system& system,
                              std::string filename, bool writable)
     : resource(path), system_(system), filename_(filename),
       writable_(writable) {}

--- a/captived/src/rest/line_resource.hpp
+++ b/captived/src/rest/line_resource.hpp
@@ -10,7 +10,7 @@ namespace rest {
 
 class line_resource : public resource {
 public:
-  line_resource(std::string path, system system, std::string filename,
+  line_resource(std::string path, system& system, std::string filename,
                 bool writable);
   ~line_resource() override = default;
 
@@ -32,7 +32,7 @@ public:
   virtual bool line(std::string new_line);
 
 protected:
-  system system_;
+  system& system_;
   std::string filename_;
   bool writable_;
 };

--- a/captived/src/rest/reboot.cpp
+++ b/captived/src/rest/reboot.cpp
@@ -4,7 +4,7 @@
 namespace captived {
 namespace rest {
 
-reboot::reboot(std::string path, system system, std::string reboot_exe)
+reboot::reboot(std::string path, system& system, std::string reboot_exe)
     : resource(path), system_(system), reboot_exe_(reboot_exe) {}
 
 int reboot::execute() { return system_.execute(reboot_exe_); }

--- a/captived/src/rest/reboot.hpp
+++ b/captived/src/rest/reboot.hpp
@@ -10,7 +10,7 @@ namespace rest {
 
 class reboot : public resource {
 public:
-  reboot(std::string path, system system, std::string reboot_exe);
+  reboot(std::string path, system& system, std::string reboot_exe);
 
   resp_type post(req_type body) override;
 
@@ -24,7 +24,7 @@ public:
   int execute();
 
 protected:
-  system system_;
+  system& system_;
   std::string reboot_exe_;
 };
 

--- a/captived/src/rest/uptime.cpp
+++ b/captived/src/rest/uptime.cpp
@@ -6,7 +6,7 @@
 namespace captived {
 namespace rest {
 
-uptime::uptime(std::string path, system system)
+uptime::uptime(std::string path, system& system)
     : resource(path), system_(system) {}
 
 std::experimental::optional<double> uptime::seconds() {

--- a/captived/src/rest/uptime.hpp
+++ b/captived/src/rest/uptime.hpp
@@ -10,7 +10,7 @@ namespace rest {
 
 class uptime : public resource {
 public:
-  uptime(std::string path, system system);
+  uptime(std::string path, system& system);
   ~uptime() override = default;
 
   resp_type get(req_type) override;
@@ -21,7 +21,7 @@ public:
   virtual std::experimental::optional<double> seconds();
 
 protected:
-  system system_;
+  system& system_;
 };
 
 } // namespace rest

--- a/captived/src/rest/wifi_config.cpp
+++ b/captived/src/rest/wifi_config.cpp
@@ -14,7 +14,7 @@ std::string sha256_hex(std::string str) {
 namespace captived {
 namespace rest {
 
-wifi_config::wifi_config(std::string path, system system,
+wifi_config::wifi_config(std::string path, system& system,
                          std::string config_file)
     : resource(path), config_file_(config_file), system_(system) {}
 

--- a/captived/src/rest/wifi_config.hpp
+++ b/captived/src/rest/wifi_config.hpp
@@ -11,7 +11,7 @@ namespace rest {
 
 class wifi_config : public resource {
 public:
-  wifi_config(std::string path, system system, std::string config_file);
+  wifi_config(std::string path, system& system, std::string config_file);
   ~wifi_config() override = default;
 
   resp_type get(req_type) override;
@@ -39,7 +39,7 @@ public:
   std::experimental::optional<std::string> sha256();
 
 protected:
-  system system_;
+  system& system_;
   std::string config_file_;
 };
 

--- a/captived/src/system.hpp
+++ b/captived/src/system.hpp
@@ -25,6 +25,9 @@ public:
    */
   system(std::string chroot) : chroot_(chroot){};
 
+  system(const system&) = delete;
+  system(system&&) = default;
+
   /**
    * Executes the provided command using the "system" call.
    */


### PR DESCRIPTION
Currently the system helper call doesn't have any interal state, but that might change in the future. It is intended to be a context-like object, so better to treat it as such from the beginning.