### PR TITLE
captived: check source code format during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ jobs:
                 set -eo pipefail
                 mkdir -p /project/captived/build
                 cd /project/captived/build
-                cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+                cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo                     \
+                         -DCHECK_FORMAT=OFF
                 cmake --build . -- -j $(nproc)
               "
       - run:

--- a/captived/CMakeLists.txt
+++ b/captived/CMakeLists.txt
@@ -8,9 +8,9 @@ project(captived
   VERSION "0.1.1"
   )
 
-
 option(BUILD_SHARED_LIBS "Build with shared libraries" ON)
 option(BUILD_SYSTEMD "Build with systemd support" ON)
+option(CHECK_FORMAT "Check source format during build" ON)
 
 enable_testing()
 
@@ -20,6 +20,11 @@ find_package(jansson REQUIRED QUIET)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
+add_custom_target(check-format
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/format.sh check || (exit 0)
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
 set(SERVER_SRCS
     src/main.cpp
@@ -61,3 +66,7 @@ if (BUILD_SYSTEMD)
 endif()
 
 add_subdirectory(integration-tests)
+
+if (CHECK_FORMAT)
+  add_dependencies(captived check-format)
+endif()

--- a/captived/format.sh
+++ b/captived/format.sh
@@ -3,8 +3,8 @@
 set -eo pipefail
 
 check() {
-    echo "
--------------------------------
+    echo \
+"-------------------------------
 Checking source code formatting
 -------------------------------"
     local rc=0


### PR DESCRIPTION
Adds a custom target check-format to the build to check the source code format.  This target prints the name of any files that are not properly formatted, but does not fail the build.