### PR TITLE
xbridge/gadget: move usb0 up/down control to xbridge

### DIFF
--- a/xap-usb-gadget/systemd/xap-usb-gadget.service.in
+++ b/xap-usb-gadget/systemd/xap-usb-gadget.service.in
@@ -4,8 +4,7 @@ Description=Set up USB gadget on wlan0
 [Service]
 Type=oneshot
 ExecStart=/bin/sh -c 'export MAC=`/bin/cat /sys/class/net/wlan0/address`; /sbin/modprobe g_ether host_addr=$MAC'
-ExecStart=/sbin/ip link set dev usb0 up
-ExecStop=/sbin/ip link set dev usb0 down
+ExecStartPost=/bin/sh -c 'sleep 1'
 ExecStop=/sbin/modprobe -r g_ether
 RemainAfterExit=true
 

--- a/xbridge/systemd/xbridge.service.in
+++ b/xbridge/systemd/xbridge.service.in
@@ -4,7 +4,9 @@ After=xap-usb-gadget.service
 
 [Service]
 Type=simple
+ExecStartPre=/sbin/ip link set dev usb0 up
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge
+ExecStopPost=/sbin/ip link set dev usb0 down
 ProtectSystem=true
 ProtectHome=true
 Restart=always

--- a/xbridge/systemd/xbridges.service.in
+++ b/xbridge/systemd/xbridges.service.in
@@ -5,7 +5,9 @@ After=enftun@enf0.service xap-usb-gadget.service
 
 [Service]
 Type=simple
+ExecStartPre=/sbin/ip link set dev usb0 up
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/xbridge -2 -n enf0
+ExecStopPost=/sbin/ip link set dev usb0 down
 ProtectSystem=true
 ProtectHome=true
 Restart=always


### PR DESCRIPTION
The xap-usb-gadget service loads the USB ethernet gadget, which creates the usb0 interface, and then bring the interface up using `ip`.  bring that interface up. However, there is some sort of race condition, because sometimes the interface is not actually brought up. The xbridge service is then unable to start.

To fix this is a safe way, bring the interface up in the xbridge service.

Since there is a known race condition, also add a small delay after loading the kernel module.