### PR TITLE
captived: pin base image for docker builds

### DIFF
--- a/captived/.docker/Dockerfile
+++ b/captived/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20190228
 MAINTAINER Xaptum
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Recent versions of the Debian Stretch docker image break the build.
Pin to a specific version so we don't get arbitrary breakages like
this in the future.