### PR TITLE
wpa-credentials: add xaprc_recovery network

### DIFF
--- a/wpa-credentials/CMakeLists.txt
+++ b/wpa-credentials/CMakeLists.txt
@@ -3,9 +3,10 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(wpa-credentials)
 
 set(WPA_INSTALL_PATH "/data/connman" CACHE PATH "The full path to store WPA credentials")
+set(WPA_RECOVERY_INSTALL_PATH "/etc/connman" CACHE PATH "The full path to store recovery WPA credentials")
 
 #Use default SSID and password if neither are set
-if("${XAPRC_SSID}" STREQUAL "" AND "${XAPRC_PASS}" STREQUAL "") 
+if("${XAPRC_SSID}" STREQUAL "" AND "${XAPRC_PASS}" STREQUAL "")
 	set(XAPRC_SSID "xaprc_default")
 	set(XAPRC_PASS "password123!")
 	message("NOTICE: No wifi credentials provided, using default SSID=" ${XAPRC_SSID} " and PASS=" ${XAPRC_PASS})
@@ -23,4 +24,14 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/passthrough-wifi.config
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/secure-host-wifi.config
         DESTINATION ${WPA_INSTALL_PATH}/secure-host
 	RENAME wifi.config
+)
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/passthrough-recovery.config
+        DESTINATION ${WPA_RECOVERY_INSTALL_PATH}/passthrough
+	RENAME recovery.config
+)
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/secure-host-recovery.config
+        DESTINATION ${WPA_RECOVERY_INSTALL_PATH}/secure-host
+	RENAME recovery.config
 )

--- a/wpa-credentials/passthrough-recovery.config
+++ b/wpa-credentials/passthrough-recovery.config
@@ -1,0 +1,6 @@
+[service_wifi_xaprc_recovery_managed_psk]
+Type = wifi
+Name = xaprc_recovery
+Passphrase = xaprc_recovery
+IPv4=off
+IPv6=off

--- a/wpa-credentials/secure-host-recovery.config
+++ b/wpa-credentials/secure-host-recovery.config
@@ -1,0 +1,4 @@
+[service_wifi_xaprc_recovery_default_managed_psk]
+Type = wifi
+Name = xaprc_recovery
+Passphrase = xaprc_recovery


### PR DESCRIPTION
The `xaprc_recovery` network will be hardcoded into all router cards
as a failsafe form of last-mile access. If a customer send a bad wifi
config that prevents the router card from reconnecting, they can
create an access point with the xaprc_recovery SSID to allow the
router card to reconnect and download an updated, corrected wifi
config.