### PR TITLE
captived: temporarily disallow the unsupported router card modes

### DIFF
--- a/captived/integration-tests/mode_Test.py
+++ b/captived/integration-tests/mode_Test.py
@@ -53,6 +53,7 @@ class mode_Test(test.SharedServer, test.IntegrationTestCase):
         resp = requests.put(URL, headers=HEADERS, json='invalid-mode')
         self.assertEqual(resp.status_code, 400)
 
+    @unittest.skip("passthrough not supported by firmware")
     def test_03_put_passthrough(self):
         resp = requests.put(URL, headers=HEADERS, json='passthrough')
         self.assertEqual(resp.status_code, 200)
@@ -66,11 +67,12 @@ class mode_Test(test.SharedServer, test.IntegrationTestCase):
         # now set an invalid mode
         resp = requests.put(URL, headers=HEADERS, json='invalid2')
         self.assertEqual(resp.status_code, 400)
-        
+
         # check mode - should not have changed.
         resp = requests.get(URL)
         self.assertEqual(resp.json(), orig_mode)
-        
+
+    @unittest.skip("secure-lan not supported by firmware")
     def test_05_put_secure_lan(self):
         resp = requests.put(URL, headers=HEADERS, json='secure-lan')
         self.assertEqual(resp.status_code, 200)

--- a/captived/src/rest/mode.cpp
+++ b/captived/src/rest/mode.cpp
@@ -7,8 +7,12 @@ namespace captived {
 namespace {
 bool
 is_valid_mode(std::string mode) {
-    return (mode == MODE_PASSTHROUGH || mode == MODE_SECURE_HOST ||
-            mode == MODE_SECURE_LAN);
+    /*
+     * As a safeguard, allow only the modes actually supported by the firmware.
+     */
+    // return (mode == MODE_PASSTHROUGH || mode == MODE_SECURE_HOST ||
+    //        mode == MODE_SECURE_LAN);
+    return (mode == MODE_SECURE_HOST);
 }
 }    // namespace
 


### PR DESCRIPTION
Just so the captive server doesn't accidentally brick any router cards if it sends an unsupported mode.