### PR TITLE
wpa-credentials: configure connman to ignore usb0 and enfX interfaces

### DIFF
--- a/wpa-credentials/CMakeLists.txt
+++ b/wpa-credentials/CMakeLists.txt
@@ -5,6 +5,7 @@ include(InstallSymlink)
 
 project(wpa-credentials)
 
+set(CONNMAN_CONF_PATH "/etc/connman" CACHE PATH "The full path to store connman config files")
 set(WPA_INSTALL_PATH "/data/connman" CACHE PATH "The full path to store WPA credentials")
 set(WPA_RECOVERY_INSTALL_PATH "/etc/connman" CACHE PATH "The full path to store recovery WPA credentials")
 
@@ -14,6 +15,11 @@ if("${XAPRC_SSID}" STREQUAL "" AND "${XAPRC_PASS}" STREQUAL "")
 	set(XAPRC_PASS "password123!")
 	message("NOTICE: No wifi credentials provided, using default SSID=" ${XAPRC_SSID} " and PASS=" ${XAPRC_PASS})
 endif()
+
+# Install connman conf file
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/main.conf
+        DESTINATION ${CONNMAN_CONF_PATH}
+)
 
 #Configure and create WPA credential conf files
 configure_file(passthrough-wifi.config.in passthrough-wifi.config @ONLY)

--- a/wpa-credentials/main.conf
+++ b/wpa-credentials/main.conf
@@ -1,0 +1,2 @@
+[General]
+NetworkInterfaceBlacklist=vmnet,vboxnet,virbr,ifb,usb,enf


### PR DESCRIPTION
By default, connman will try to control the usb0, enf0, and enf1
interfaces.  This has normally worked ok, but it can cause problems.
For example, if connman is restarted or stopped, it will change each
of the interface states to "down", which breaks forwarding.

So, prevent these potential problems by instructing connman to
completely ignore interfaces that start with usb or enf (in addition to the defaults vmnet, vboxnet, etc.)